### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#LoadingDots for Android
+# LoadingDots for Android
 
 Customizable bouncing dots view for smooth loading effect. Mostly used in chat bubbles to indicate the other person is typing.
 
-##Features
+## Features
 
  - LoadingDots animated view
  - Use in xml
@@ -10,17 +10,17 @@ Customizable bouncing dots view for smooth loading effect. Mostly used in chat b
  - Customize animation behavior
  - Customize animation duration
 
-##Demo
+## Demo
 
 ![](screens/demo.gif)
 
-##Import
+## Import
 
  ```xml
     compile 'com.eyalbira.loadingdots:loading-dots:1.0.2'
  ```
 
-##Usage
+## Usage
 
 For basic usage, simply add to layout xml:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
