### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Customizable bouncing dots view for smooth loading effect. Mostly used in chat b
 ## Import
 
  ```xml
-    compile 'com.eyalbira.loadingdots:loading-dots:1.0.2'
+    implementation 'com.eyalbira.loadingdots:loading-dots:1.0.2'
  ```
 
 ## Usage


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.